### PR TITLE
Add Rmpi example

### DIFF
--- a/MPI/README.md
+++ b/MPI/README.md
@@ -1,0 +1,42 @@
+# Using R and MPI on ACCRE
+
+## Installing Rmpi
+
+You'll need to install the [Rmpi](http://cran.r-project.org/package=Rmpi) package from source and compile it against the version of OpenMPI you're using.  First, add R, the GCC compiler, and the OpenMPI version of your choice to your PATH.
+
+```bash
+setpkgs -a R_3.1.1
+setpkgs -a gcc_compiler
+setpkgs -a openmpi_1.8.4
+```
+
+Next, download the Rmpi source code.
+
+```bash
+cd /tmp
+wget http://cran.r-project.org/src/contrib/Rmpi_0.6-5.tar.gz
+```
+
+You'll need to supply the directory containing the OpenMPI `include/` and `lib/` directories when you install the package.  For the version of OpenMPI used here (1.8.4), the relevant directory is `/usr/local/openmpi/1.8.4/x86_64/gcc46`.
+
+```bash
+R CMD INSTALL Rmpi_0.6-5.tar.gz --configure-args=--with-mpi=/usr/local/openmpi/1.8.4/x86_64/gcc46
+```
+
+Using Rmpi is much easier, at least for embarrassingly parallel applications, with the [doMPI](http://cran.r-project.org/web/packages/doMPI/index.html) package.  To install this package from CRAN, just run the following in an R session:
+
+```r
+install.packages("doMPI")
+```
+
+When installing the Rmpi and doMPI packages, don't worry if you see the following warning message:
+
+    PMI2 initialized but returned bad values for size and rank.
+    This is symptomatic of either a failure to use the
+    "--mpi=pmi2" flag in SLURM, or a borked PMI2 installation.
+    If running under SLURM, try adding "-mpi=pmi2" to your
+    srun command line. If that doesn't work, or if you are
+    not running under SLURM, try removing or renaming the
+    pmi2.h header file so PMI2 support will not automatically
+    be built, reconfigure and build OMPI, and then try again
+    with only PMI1 support enabled.

--- a/MPI/rmpi.R
+++ b/MPI/rmpi.R
@@ -1,0 +1,27 @@
+library("Rmpi", quietly = TRUE)
+library("doMPI", quietly = TRUE)
+
+## Set up error handling with Rmpi
+##
+## Without this code, the MPI session may fail to shut down properly in case an
+## error occurs, and then the script won't terminate until it hits the walltime
+options(error=quote(assign(".mpi.err", FALSE, env = .GlobalEnv)))
+
+## Set up the cluster via Rmpi
+##
+## If started via `srun`, it should detect from the environment how many CPUs
+## are available, so we don't need to tell it
+cl <- startMPIcluster()
+
+## Tell `foreach` to parallelize on the MPI cluster
+registerDoMPI(cl)
+
+## Run loop in parallel over MPI
+system.time(foreach (i = 1:16) %dopar% { Sys.sleep(10); mean(rnorm(1e4)) })
+
+## Run sequentially as benchmark
+system.time(foreach (i = 1:16) %do% { Sys.sleep(10); mean(rnorm(1e4)) })
+
+## Shut down the cluster and exit the R session
+closeCluster(cl)
+mpi.quit()

--- a/MPI/rmpi.slurm
+++ b/MPI/rmpi.slurm
@@ -1,0 +1,13 @@
+#!/bin/bash
+#SBATCH --mail-user=vunetid@vanderbilt.edu
+#SBATCH --mail-type=ALL
+#SBATCH --nodes=2
+#SBATCH --tasks-per-node=4
+#SBATCH --time=00:10:00        # 10 minutes
+#SBATCH --mem=500M
+#SBATCH --output=R_job_slurm.out
+
+setpkgs -a R_3.1.1
+setpkgs -a openmpi_1.8.4
+
+srun --mpi=pmi2 Rscript rmpi.R


### PR DESCRIPTION
I've written up a minimal example of using Rmpi on ACCRE, along with instructions for a user to install the Rmpi package. I'm hoping this can be useful to others who want to run R code in parallel without having to divide jobs into batches.
